### PR TITLE
Internal connections should always connect with flypgadmin

### DIFF
--- a/pkg/flypg/node.go
+++ b/pkg/flypg/node.go
@@ -64,7 +64,7 @@ func NewNode() (*Node, error) {
 
 func (n *Node) NewLocalConnection(ctx context.Context) (*pgx.Conn, error) {
 	host := net.JoinHostPort(n.PrivateIP.String(), strconv.Itoa(n.PGPort))
-	return openConnection(ctx, host, n.OperatorCredentials)
+	return openConnection(ctx, host, n.SUCredentials)
 }
 
 func openConnection(ctx context.Context, host string, creds Credentials) (*pgx.Conn, error) {


### PR DESCRIPTION
Create a clean separation between connections opened via Fly vs. connections opened directly by the user.